### PR TITLE
Set user shell to /bin/bash

### DIFF
--- a/src/open-semantic-desktop-search/playbook.yml
+++ b/src/open-semantic-desktop-search/playbook.yml
@@ -162,6 +162,7 @@
         name: user
         comment: User
         group: user
+        shell: /bin/bash
         # Add to group sudo for root access
         # Add to group vboxsf for access to shared folders of the VM
         groups: sudo, vboxsf


### PR DESCRIPTION
Hi, thanks for building open semantic search!

I understand this might be a personal preference, but while testing Open-Semantic-Search I found that setting the shell for user user to /bin/bash could help interface with the system. I found myself switching to bash to display the current folder and/or to use completion. Perhaps, this could be added to the default ansible code?